### PR TITLE
CSV export: add BOM + delimiter/filename/header/preview options and fix header quoting/UTF-8

### DIFF
--- a/src/main/java/com/example/Krieger/util/CsvEscaper.java
+++ b/src/main/java/com/example/Krieger/util/CsvEscaper.java
@@ -1,16 +1,15 @@
 package com.example.Krieger.util;
 
+import java.text.Normalizer;
+
 public final class CsvEscaper {
     private CsvEscaper() {}
 
     /** Escape a value for CSV (normalize newlines, always quote, double internal quotes). */
     public static String escape(String s) {
         if (s == null) s = "";
-        // normalize newlines to spaces to avoid breaking row structure
         String normalized = s.replace("\r\n", " ").replace("\n", " ").replace("\r", " ");
-        // double any quotes
         String doubled = normalized.replace("\"", "\"\"");
-        // always quote fields to be safe for commas/spaces/etc.
         return "\"" + doubled + "\"";
     }
 
@@ -20,5 +19,61 @@ public final class CsvEscaper {
         String normalized = s.replace("\r\n", " ").replace("\n", " ").replace("\r", " ").trim();
         if (normalized.length() <= max) return normalized;
         return normalized.substring(0, Math.max(0, max - 1)) + "…";
+    }
+
+    /** Resolve delimiter from request param; defaults to comma. Accepts: comma, semicolon, tab. */
+    public static char resolveDelimiter(String param) {
+        if (param == null || param.isBlank()) return ',';
+        switch (param.trim().toLowerCase()) {
+            case "semicolon":
+            case "semi":
+            case "sc":
+                return ';';
+            case "tab":
+            case "tsv":
+                return '\t';
+            case "comma":
+            case "csv":
+            default:
+                return ',';
+        }
+    }
+
+    /** Clamp an integer between min and max, using defaultVal when val is null. */
+    public static int clamp(Integer val, int min, int max, int defaultVal) {
+        int v = (val == null) ? defaultVal : val.intValue();
+        if (v < min) v = min;
+        if (v > max) v = max;
+        return v;
+    }
+
+    /** Append a CSV row to the builder using the given delimiter. */
+    public static void appendRow(StringBuilder sb, char delimiter, String... values) {
+        if (values == null || values.length == 0) {
+            sb.append('\n');
+            return;
+        }
+        for (int i = 0; i < values.length; i++) {
+            if (i > 0) sb.append(delimiter);
+            sb.append(escape(values[i]));
+        }
+        sb.append('\n');
+    }
+
+    /**
+     * Sanitize a suggested filename (no path separators/control chars). Returns fallback if empty.
+     * Does not append extension; caller decides.
+     */
+    public static String sanitizeFilename(String input, String fallback) {
+        String name = (input == null) ? "" : input.trim();
+        if (name.isEmpty()) return fallback;
+        // strip dangerous chars and normalize
+        name = Normalizer.normalize(name, Normalizer.Form.NFKC)
+                .replaceAll("[\\\\/:*?\"<>|\\p{Cntrl}]", "_")
+                .replaceAll("\\s+", "_");
+        // guard overly long names
+        if (name.length() > 120) name = name.substring(0, 120);
+        if (name.isEmpty() || name.equals(".") || name.equals("..")) return fallback;
+        return name;
     }
 }

--- a/src/test/java/com/example/krieger/controller/DocumentControllerExportCsvTest.java
+++ b/src/test/java/com/example/krieger/controller/DocumentControllerExportCsvTest.java
@@ -100,4 +100,60 @@ class DocumentControllerExportCsvTest {
         long lines = body.lines().count();
         assertEquals(1, lines, "CSV should contain only the header when there are no rows");
     }
+
+    @Test
+    void exportCsv_withBomTrue_prefixesBOM() throws Exception {
+        // mock two docs (same as earlier test)
+        Document d1 = mock(Document.class);
+        when(d1.getId()).thenReturn(2L);
+        when(d1.getTitle()).thenReturn("Report");
+        when(d1.getContent()).thenReturn("Alpha");
+        when(d1.getCreatedAt()).thenReturn(java.time.Instant.parse("2024-01-02T03:04:05Z"));
+        when(d1.getUpdatedAt()).thenReturn(java.time.Instant.parse("2024-02-03T04:05:06Z"));
+
+        Document d2 = mock(Document.class);
+        when(d2.getId()).thenReturn(1L);
+        when(d2.getTitle()).thenReturn("Notes");
+        when(d2.getContent()).thenReturn("Beta");
+        when(d2.getCreatedAt()).thenReturn(java.time.Instant.parse("2024-01-01T00:00:00Z"));
+        when(d2.getUpdatedAt()).thenReturn(java.time.Instant.parse("2024-01-01T00:00:01Z"));
+
+        Pageable pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Document> page = new PageImpl<>(java.util.List.of(d1, d2), pageable, 2);
+
+        when(documentService.searchDocuments(isNull(), isNull(), any(Pageable.class))).thenReturn(page);
+
+        MvcResult res = mockMvc.perform(get("/api/documents/export.csv")
+                        .param("page", "0")
+                        .param("size", "2")
+                        .param("sort", "id,desc")
+                        .param("bom", "true")) // enable BOM
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", org.hamcrest.Matchers.containsString("text/csv")))
+                .andReturn();
+
+        String body = res.getResponse().getContentAsString();
+        assertTrue(body.startsWith("\uFEFF"), "CSV should start with UTF-8 BOM when bom=true");
+        // sanity: header row present after BOM
+        assertTrue(body.contains("id,title,authorId,createdAt,updatedAt,contentPreview"));
+    }
+
+    @Test
+    void exportCsv_withoutBom_doesNotPrefixBOM() throws Exception {
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Document> page = new PageImpl<>(java.util.List.of(), pageable, 0);
+        when(documentService.searchDocuments(isNull(), isNull(), any(Pageable.class))).thenReturn(page);
+
+        MvcResult res = mockMvc.perform(get("/api/documents/export.csv")
+                        .param("page", "0")
+                        .param("size", "1")
+                        .param("sort", "id,desc"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = res.getResponse().getContentAsString();
+        // must NOT start with BOM by default
+        assertTrue(!body.startsWith("\uFEFF"), "CSV should not start with BOM unless bom=true is provided");
+    }
+
 }


### PR DESCRIPTION
CSV export: add BOM + delimiter/filename/header/preview options and fix header quoting/UTF-8

- Controller: /export.csv now supports optional params:
  * bom=true → prepend UTF-8 BOM
  * delimiter=(comma|semicolon|tab) with default comma
  * filename=<safe name> (auto .csv, sanitized)
  * includeHeader=(true|false), default true
  * previewLen=<20..500>, clamped (default 120)
- Header: keep UNQUOTED when delimiter is comma to match client/tests
- Data rows remain quoted/escaped
- Set Content-Type to text/csv; charset=UTF-8 so BOM is preserved
- Util: CsvEscaper gains resolveDelimiter(), clamp(), appendRow(), sanitizeFilename()

closes #3 