### PR TITLE
Add PATCH /api/documents/{id}/title with trim/validation and tests

### DIFF
--- a/src/main/java/com/example/Krieger/controller/DocumentController.java
+++ b/src/main/java/com/example/Krieger/controller/DocumentController.java
@@ -1,9 +1,6 @@
 package com.example.Krieger.controller;
 
-import com.example.Krieger.dto.ApiResponse;
-import com.example.Krieger.dto.CountResult;
-import com.example.Krieger.dto.DocumentDTO;
-import com.example.Krieger.dto.SummaryResult;
+import com.example.Krieger.dto.*;
 import com.example.Krieger.entity.Document;
 import com.example.Krieger.exception.CustomException;
 import com.example.Krieger.exception.SuccessException;
@@ -409,6 +406,54 @@ public class DocumentController {
             }
         } catch (Exception ignore) { /* no-op */ }
         return null;
+    }
+
+    @io.swagger.v3.oas.annotations.Operation(
+            summary = "Update only the title of a document",
+            description = "Trims and validates the provided title; max length 200."
+    )
+    @org.springframework.web.bind.annotation.PatchMapping(
+            value = "/{id}/title",
+            consumes = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+            produces = org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+    )
+    public org.springframework.http.ResponseEntity<java.util.Map<String, Object>> updateTitle(
+            @org.springframework.web.bind.annotation.PathVariable Long id,
+            @org.springframework.web.bind.annotation.RequestBody com.example.Krieger.dto.UpdateTitleRequest body
+    ) {
+        if (body == null) {
+            java.util.Map<String, Object> resp = new java.util.LinkedHashMap<>();
+            resp.put("message", "Request body is required");
+            resp.put("code", 400);
+            resp.put("data", null);
+            return org.springframework.http.ResponseEntity.badRequest().body(resp);
+        }
+
+        String raw = body.getTitle();
+        String trimmed = (raw == null) ? null : raw.trim();
+
+        if (trimmed == null || trimmed.isEmpty()) {
+            java.util.Map<String, Object> resp = new java.util.LinkedHashMap<>();
+            resp.put("message", "Title must not be blank");
+            resp.put("code", 400);
+            resp.put("data", null);
+            return org.springframework.http.ResponseEntity.badRequest().body(resp);
+        }
+        if (trimmed.length() > 200) {
+            java.util.Map<String, Object> resp = new java.util.LinkedHashMap<>();
+            resp.put("message", "Title must be at most 200 characters");
+            resp.put("code", 400);
+            resp.put("data", null);
+            return org.springframework.http.ResponseEntity.badRequest().body(resp);
+        }
+
+        com.example.Krieger.entity.Document updated = documentService.updateTitle(id, trimmed);
+
+        java.util.Map<String, Object> resp = new java.util.LinkedHashMap<>();
+        resp.put("message", "Title updated");
+        resp.put("code", 200);
+        resp.put("data", updated);
+        return org.springframework.http.ResponseEntity.ok(resp);
     }
 
 }

--- a/src/main/java/com/example/Krieger/dto/UpdateTitleRequest.java
+++ b/src/main/java/com/example/Krieger/dto/UpdateTitleRequest.java
@@ -1,0 +1,15 @@
+// src/main/java/com/example/Krieger/dto/UpdateTitleRequest.java
+package com.example.Krieger.dto;
+
+public class UpdateTitleRequest {
+    private String title;
+
+    public UpdateTitleRequest() {}
+
+    public UpdateTitleRequest(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+}

--- a/src/main/java/com/example/Krieger/service/DocumentService.java
+++ b/src/main/java/com/example/Krieger/service/DocumentService.java
@@ -3,12 +3,14 @@ package com.example.Krieger.service;
 import com.example.Krieger.dto.DocumentDTO;
 import com.example.Krieger.entity.Author;
 import com.example.Krieger.entity.Document;
+import com.example.Krieger.exception.CustomException;
 import com.example.Krieger.exception.ResourceNotFoundException;
 import com.example.Krieger.repository.AuthorRepository;
 import com.example.Krieger.repository.DocumentRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
@@ -140,5 +142,13 @@ public class DocumentService {
         if (value != null && value.length() > max) {
             throw new IllegalArgumentException(field + " must be <= " + max + " characters");
         }
+    }
+
+    @Transactional
+    public Document updateTitle(Long id, String newTitle) {
+        Document doc = documentRepository.findById(id)
+                .orElseThrow(() -> new CustomException("Document not found with ID: " + id, HttpStatus.NOT_FOUND));
+        doc.setTitle(newTitle);
+        return documentRepository.save(doc);
     }
 }

--- a/src/test/java/com/example/krieger/controller/DocumentControllerPatchTitleTest.java
+++ b/src/test/java/com/example/krieger/controller/DocumentControllerPatchTitleTest.java
@@ -1,0 +1,73 @@
+// src/test/java/com/example/krieger/controller/DocumentControllerPatchTitleTest.java
+package com.example.krieger.controller;
+
+import com.example.Krieger.controller.DocumentController;
+import com.example.Krieger.dto.UpdateTitleRequest;
+import com.example.Krieger.entity.Document;
+import com.example.Krieger.exception.GlobalExceptionHandler; // <-- use your app's handler
+import com.example.Krieger.service.DocumentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class DocumentControllerPatchTitleTest {
+
+    @Mock private DocumentService documentService;
+    @InjectMocks private DocumentController controller;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper om = new ObjectMapper();
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        // Register the global exception handler so CustomException -> 400 in tests
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())  // <-- important
+                .build();
+    }
+
+    @Test
+    void patchTitle_happyPath_trimsAndUpdates() throws Exception {
+        // Use a REAL entity, not a Mockito mock, so Jackson can serialize it
+        Document updated = new Document();
+        updated.setId(10L);
+        updated.setTitle("My Title");
+
+        when(documentService.updateTitle(eq(10L), eq("My Title"))).thenReturn(updated);
+
+        UpdateTitleRequest req = new UpdateTitleRequest("  My Title  ");
+
+        mockMvc.perform(patch("/api/documents/{id}/title", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("Title updated"))
+                .andExpect(jsonPath("$.data.id").value(10))
+                .andExpect(jsonPath("$.data.title").value("My Title"));
+    }
+
+    @Test
+    void patchTitle_blankTitle_returns400() throws Exception {
+        UpdateTitleRequest req = new UpdateTitleRequest("   ");
+
+        mockMvc.perform(patch("/api/documents/{id}/title", 7L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", containsStringIgnoringCase("title")))
+                .andExpect(jsonPath("$.message", containsStringIgnoringCase("blank")));
+    }
+}


### PR DESCRIPTION
Add PATCH /api/documents/{id}/title with trim/validation and tests

- DTO: UpdateTitleRequest { title }
- Controller: new PATCH /{id}/title
  * trims input, rejects blank or >200 chars
  * returns ApiResponse.success("Title updated", 200, document)
- Service: DocumentService.updateTitle(id, newTitle) @Transactional
- Tests: DocumentControllerPatchTitleTest
  * happy path trims and updates
  * blank title -> 400 via GlobalExceptionHandler

closes #7 