### PR TITLE
Add GET /api/documents/{id}/metrics (word/char/line counts + reading time)

### DIFF
--- a/src/main/java/com/example/Krieger/dto/TextMetricsResult.java
+++ b/src/main/java/com/example/Krieger/dto/TextMetricsResult.java
@@ -1,0 +1,23 @@
+package com.example.Krieger.dto;
+
+public class TextMetricsResult {
+    private final Long id;
+    private final int words;
+    private final int characters;
+    private final int lines;
+    private final int readingTimeSeconds;
+
+    public TextMetricsResult(Long id, int words, int characters, int lines, int readingTimeSeconds) {
+        this.id = id;
+        this.words = words;
+        this.characters = characters;
+        this.lines = lines;
+        this.readingTimeSeconds = readingTimeSeconds;
+    }
+
+    public Long getId() { return id; }
+    public int getWords() { return words; }
+    public int getCharacters() { return characters; }
+    public int getLines() { return lines; }
+    public int getReadingTimeSeconds() { return readingTimeSeconds; }
+}

--- a/src/main/java/com/example/Krieger/util/TextMetrics.java
+++ b/src/main/java/com/example/Krieger/util/TextMetrics.java
@@ -1,0 +1,56 @@
+package com.example.Krieger.util;
+
+public final class TextMetrics {
+
+    private TextMetrics() {}
+
+    /** Normalize CRLF/CR to LF. */
+    public static String normalizeNewlines(String s) {
+        if (s == null) return "";
+        return s.replace("\r\n", "\n").replace("\r", "\n");
+    }
+
+    /** Count words after trimming; split on Unicode whitespace. */
+    public static int countWords(String s) {
+        if (s == null) return 0;
+        String t = s.trim();
+        if (t.isEmpty()) return 0;
+        String[] parts = t.split("\\s+");
+        int c = 0;
+        for (String p : parts) {
+            if (!p.isEmpty()) c++;
+        }
+        return c;
+    }
+
+    /** Count characters (including spaces and newlines) after normalization. */
+    public static int countChars(String normalized) {
+        if (normalized == null) return 0;
+        return normalized.length();
+    }
+
+    /** Count lines by LF after normalization. Returns 0 for empty text, else (#LF + 1). */
+    public static int countLines(String normalized) {
+        if (normalized == null || normalized.isBlank()) return 0;
+        int lines = 1;
+        for (int i = 0; i < normalized.length(); i++) {
+            if (normalized.charAt(i) == '\n') lines++;
+        }
+        return lines;
+    }
+
+    /** Clamp WPM to [100..400], use default if null/invalid. */
+    public static int clampWpm(Integer wpmParam, int defaultWpm) {
+        int wpm = (wpmParam == null) ? defaultWpm : wpmParam.intValue();
+        if (wpm < 100) wpm = 100;
+        if (wpm > 400) wpm = 400;
+        return wpm;
+    }
+
+    /** ceil(words / wpm * 60); zero words => 0 seconds. */
+    public static int estimateReadingTimeSeconds(int words, int wpm) {
+        if (words <= 0) return 0;
+        double seconds = ((double) words / (double) wpm) * 60.0;
+        return (int) Math.ceil(seconds);
+    }
+}

--- a/src/test/java/com/example/krieger/controller/DocumentControllerMetricsTest.java
+++ b/src/test/java/com/example/krieger/controller/DocumentControllerMetricsTest.java
@@ -1,0 +1,87 @@
+// src/test/java/com/example/krieger/controller/DocumentControllerMetricsTest.java
+package com.example.krieger.controller;
+
+import com.example.Krieger.controller.DocumentController;
+import com.example.Krieger.entity.Document;
+import com.example.Krieger.service.DocumentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class DocumentControllerMetricsTest {
+
+    @Mock
+    private DocumentService documentService;
+
+    @InjectMocks
+    private DocumentController controller;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void metrics_default_stripHtmlTrue_wpmDefault200_countsAndReadingTime() throws Exception {
+        // HTML content that collapses to "Hi A B C"
+        String html = "<h1>Hi</h1>\r\n<p>A B C</p>\n";
+
+        Document d = org.mockito.Mockito.mock(Document.class);
+        when(d.getId()).thenReturn(123L);
+        when(d.getContent()).thenReturn(html);
+
+        when(documentService.getDocumentById(anyLong())).thenReturn(d);
+
+        mockMvc.perform(get("/api/documents/{id}/metrics", 123L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("Metrics computed"))
+                .andExpect(jsonPath("$.data.id").value(123))
+                // After stripHtml + collapse: "Hi A B C" → words=4, chars=8, lines=1
+                .andExpect(jsonPath("$.data.words").value(4))
+                .andExpect(jsonPath("$.data.characters").value(8))
+                .andExpect(jsonPath("$.data.lines").value(1))
+                // reading time = ceil(4/200*60) = 2
+                .andExpect(jsonPath("$.data.readingTimeSeconds").value(2));
+    }
+
+    @Test
+    void metrics_withParams_stripHtmlFalse_wpm300_countsRespectParams() throws Exception {
+        // raw text with explicit newlines → lines=4 (includes blank line)
+        String raw = "L1\nL2\n\nL4";
+
+        Document d = org.mockito.Mockito.mock(Document.class);
+        when(d.getId()).thenReturn(9L);
+        when(d.getContent()).thenReturn(raw);
+
+        when(documentService.getDocumentById(9L)).thenReturn(d);
+
+        mockMvc.perform(get("/api/documents/{id}/metrics", 9L)
+                        .param("stripHtml", "false")
+                        .param("wpm", "300")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.msg").value("Metrics computed"))
+                .andExpect(jsonPath("$.data.id").value(9))
+                // "L1\nL2\n\nL4": words=3 ("L1","L2","L4"), chars=9 (includes newlines), lines=4
+                .andExpect(jsonPath("$.data.words").value(3))
+                .andExpect(jsonPath("$.data.characters").value(9))
+                .andExpect(jsonPath("$.data.lines").value(4))
+                // reading time = ceil(3/300*60) = 1
+                .andExpect(jsonPath("$.data.readingTimeSeconds").value(1));
+    }
+}


### PR DESCRIPTION
Add GET /api/documents/{id}/metrics (word/char/line counts + reading time)

- DTO: TextMetricsResult { id, words, characters, lines, readingTimeSeconds }
- Util: TextMetrics (normalize, countWords/Chars/Lines, clampWpm, estimateReadingTimeSeconds)
- Controller: new /{id}/metrics endpoint with stripHtml (default true) and wpm (default 200, clamped 100..400)
- Tests: DocumentControllerMetricsTest (default + custom params)


closes #15 